### PR TITLE
CI ubuntu build

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: installcurses
+      run: sudo apt-get -y install libncurses-dev
+    - name: configure
+      run: cd sys/unix; sh setup.sh hints/linux; cd ../..
+    - name: make
+      run: make


### PR DESCRIPTION
CI setup that work against NetHack 3.6.2 (see: https://github.com/MikkoSpoo/NetHack/pull/2).